### PR TITLE
Fix class loading issue

### DIFF
--- a/classes/footer.php
+++ b/classes/footer.php
@@ -51,6 +51,7 @@ class footer {
         global $CFG, $DB, $OUTPUT, $SITE;
 
         require_once($CFG->dirroot . '/user/lib.php');
+        require_once($CFG->dirroot . '/user/profile/lib.php');
 
         $user = $this->user;
         profile_load_data($user);


### PR DESCRIPTION
profile_load_data requires `/user/profile/lib.php`

This seems to have usually been loaded by this point, but apparently wasn't on a couple of pages in some rare cases. I couldn't replicate this, but should be safe to add the require.