### PR TITLE
Add manage capability and move template to own page #25

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ The easiest way to get started as an administrator is to:
 
 1) populate your own user profile with any data that you might want exposed
    in your email template
-2) Visit the admin settings /admin/settings.php?section=manageemailtemplate and you
+2) Visit the admin settings /admin/tool/emailtemplate/template.php and you
    will see a json data structure of all the data available to be used in your mustache template
 3) Fill in the email mustache template and previewing it on your own profile page (see below). 
    For mustache syntax see: http://mustache.github.io/mustache.5.html

--- a/classes/footer.php
+++ b/classes/footer.php
@@ -164,8 +164,8 @@ class footer {
     public function get_html(): string {
         $mustache = $this->get_mustache();
         $data = $this->get_data();
-        $config = get_config('tool_emailtemplate');
-        $footer = $mustache->render($config->template, $data);
+        $template = get_config('tool_emailtemplate', 'template');
+        $footer = $mustache->render($template, $data);
 
         // Clean up blank lines.
         $footer = preg_replace('/\s*($|\n)/', '\1', $footer);

--- a/classes/form/template.php
+++ b/classes/form/template.php
@@ -1,0 +1,151 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Form to manage the template.
+ *
+ * @package    tool_emailtemplate
+ * @author     Benjamin Walker <benjaminwalker@catalyst-au.net>
+ * @copyright  2024, Catalyst IT
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace tool_emailtemplate\form;
+
+defined('MOODLE_INTERNAL') || die();
+
+require_once("$CFG->libdir/formslib.php");
+
+/**
+ * Manage template form.
+ */
+class template extends \moodleform {
+    /** @var array config settings attached to the form */
+    protected const FORM_CONFIG = [
+        'template',
+        'global_vars',
+    ];
+
+    /** @var array config */
+    protected $config;
+
+    /**
+     * Form definition
+     *
+     * @return void
+     */
+    public function definition(): void {
+        global $CFG, $DB, $USER;
+
+        $mform = $this->_form;
+
+        // Template.
+        // This needs to be a configtextarea and not a confightmleditor because
+        // atto & html tidy will mangle the mustache tags.
+        $mform->addElement('textarea', 'template', get_string('configtemplate', 'tool_emailtemplate'), [
+            'cols' => 60,
+            'rows' => 30,
+        ]);
+        $mform->setType('template', PARAM_RAW);
+
+        $data = (new \tool_emailtemplate\footer($USER))->get_data();
+        $data = '<pre>' . json_encode($data, JSON_PRETTY_PRINT) . '</pre>';
+        $mform->addElement('static', 'template_help', '', get_string('configtemplate_help', 'tool_emailtemplate') . $data);
+
+        // Global vars.
+        $mform->addElement('textarea', 'global_vars', get_string('global_vars', 'tool_emailtemplate'), [
+            'cols' => 60,
+            'rows' => 8,
+        ]);
+        $mform->setType('global_vars', PARAM_RAW);
+        $mform->addElement('static', 'global_vars_help', '', get_string('global_vars_desc', 'tool_emailtemplate'));
+
+        // Images.
+        $mform->addElement('filemanager', 'images', get_string('images', 'tool_emailtemplate'), null,
+            $this->get_filemanager_options()
+        );
+        $mform->addElement('static', 'images_help', '', get_string('imagesdesc', 'tool_emailtemplate'));
+
+        $this->add_action_buttons(false);
+    }
+
+    /**
+     * Returns the filemanager options for this form.
+     *
+     * @return array filemanager options.
+     */
+    public static function get_filemanager_options(): array {
+        return [
+            'accepted_types' => ['web_image'],
+            'maxbytes' => 0,
+            'subdirs' => 0,
+            'maxfiles' => 8,
+        ];
+    }
+
+    /**
+     * Loads the current values of the form config.
+     * @return void
+     */
+    public function load_form_config(): void {
+        $config = [];
+        foreach (self::FORM_CONFIG as $name) {
+            $config[$name] = get_config('tool_emailtemplate', $name);
+        }
+
+        // Also load the images id.
+        $draftitemid = file_get_submitted_draft_itemid('images');
+        file_prepare_draft_area(
+            $draftitemid,
+            \context_system::instance()->id,
+            'tool_emailtemplate',
+            'images',
+            0,
+            self::get_filemanager_options()
+        );
+        $config['images'] = $draftitemid;
+
+        // Save empty config values but don't set them. Needed for comparisons.
+        $this->config = $config;
+        $this->set_data(array_filter($config));
+    }
+
+    /**
+     * Saves the new form data to config.
+     * @param \stdClass $data submitted data
+     * @return void
+     */
+    public function save_form_config(\stdClass $data): void {
+        foreach ($data as $key => $value) {
+            if (in_array($key, self::FORM_CONFIG) && $value !== $this->config[$key]) {
+                set_config($key, $value, 'tool_emailtemplate');
+                add_to_config_log($key, (string) $this->config[$key], $value, 'tool_emailtemplate');
+            }
+        }
+
+        // Save draft images.
+        if (isset($data->images)) {
+            file_save_draft_area_files(
+                $data->images,
+                \context_system::instance()->id,
+                'tool_emailtemplate',
+                'images',
+                0,
+                self::get_filemanager_options()
+            );
+        }
+    }
+}

--- a/db/access.php
+++ b/db/access.php
@@ -40,4 +40,13 @@ $capabilities = [
             'manager' => CAP_ALLOW
         ],
     ],
+    'tool/emailtemplate:manage' => [
+
+        'riskbitmask' => RISK_XSS | RISK_CONFIG,
+        'captype' => 'write',
+        'contextlevel' => CONTEXT_SYSTEM,
+        'archetypes' => [
+            'manager' => CAP_ALLOW,
+        ],
+    ],
 ];

--- a/index.php
+++ b/index.php
@@ -81,5 +81,12 @@ document.getElementById('copy').addEventListener('click', function(e) {
 </script>
 EOF;
 
+if (has_capability('tool/emailtemplate:manage', context_system::instance())) {
+    $manageurl = new moodle_url('/admin/tool/emailtemplate/template.php');
+    echo html_writer::link($manageurl, get_string('emailtemplate:manage', 'tool_emailtemplate'), [
+        'class' => 'btn btn-secondary',
+    ]);
+}
+
 echo $OUTPUT->footer();
 

--- a/lang/en/tool_emailtemplate.php
+++ b/lang/en/tool_emailtemplate.php
@@ -30,12 +30,13 @@ $string['configtemplate_help'] = 'A mustache template for the email template';
 $string['copytoclipboard'] = 'Copy to clipboard';
 $string['customprofilefield:default'] = 'None';
 $string['customprofilefield:displayname'] = '{$a->name} ({$a->shortname})';
-$string['emailtemplate:view'] = 'View Email footer template';
+$string['emailtemplate:view'] = 'View email footer template';
+$string['emailtemplate:manage'] = 'Manage email footer template';
 $string['global_vars'] = 'Global variables';
 $string['global_vars_desc'] = "Global variables that can be accessed within the template as {{global.&lt;name&gt;}}.
     Variables should be defined as 'name: value', with each variable being on a new line.";
 $string['images'] = 'Images';
-$string['imagesdesc'] = 'These images can be used in the email template. If the image filename is example.jpg then in the template use {{images.example}} without the extension. You can replace images in place and have the footers dynamcially replaced, but do NOT swap it\'s extension. If you have ever used an image then you should keep it indefinetly to no break old footers still being seen.';
+$string['imagesdesc'] = 'These images can be used in the email template. If the image filename is example.jpg then in the template use {{images.example}} without the extension. You can replace images in place and have the footers dynamcially replaced, but do NOT swap it\'s extension. If you have ever used an image then you should keep it indefinetly to not break old footers still being seen.';
 $string['pluginfile'] = 'Email footer template';
 $string['pluginname'] = 'Email footer template';
 $string['privacy:metadata:tool_emailtemplate_tracking'] = 'The Email footer template plugin has an optional setting that enables tracking of template versions.';

--- a/lib.php
+++ b/lib.php
@@ -92,7 +92,7 @@ function tool_emailtemplate_pluginfile($course, $cm, $context, $filearea, $args,
  * @return void
  */
 function tool_emailtemplate_update_tracking($info) {
-    GLOBAL $DB;
+    global $DB;
 
     // Confirm data is formatted correctly and contains the required info.
     $date = date('Y-m-d');

--- a/settings.php
+++ b/settings.php
@@ -26,41 +26,17 @@
 defined('MOODLE_INTERNAL') || die();
 
 if ($hassiteconfig) {
+    $category = new admin_category('tool_emailtemplate', get_string('pluginname', 'tool_emailtemplate'));
+    $ADMIN->add('tools', $category);
 
-    $settings = new admin_settingpage('manageemailtemplate', new lang_string('pluginfile', 'tool_emailtemplate'));
-    $ADMIN->add('tools', $settings);
+    $settings = new admin_settingpage('tool_emailtemplate_settings', get_string('generalsettings', 'admin'));
+    $ADMIN->add('tool_emailtemplate', $settings);
 
-    // This needs to be a configtextarea and not a confightmleditor because
-    // atto & html tidy will mangle the mustache tags.
-
-    $data = (new \tool_emailtemplate\footer($USER))->get_data();
-    $data = '<pre>' . json_encode($data, JSON_PRETTY_PRINT) . '</pre>';
-
-    $settings->add(new admin_setting_configtextarea(
-        'tool_emailtemplate/template',
-        get_string('configtemplate', 'tool_emailtemplate'),
-        get_string('configtemplate_help', 'tool_emailtemplate') . $data,
-        '',
-        PARAM_RAW,
-        60,
-        30
-    ));
-
-    $settings->add(new admin_setting_configtextarea(
-        'tool_emailtemplate/global_vars',
-        get_string('global_vars', 'tool_emailtemplate'),
-        get_string('global_vars_desc', 'tool_emailtemplate'),
-        '',
-        PARAM_RAW
-    ));
-
-    $settings->add(new admin_setting_configstoredfile(
-        'tool_emailtemplate/images',
-        get_string('images', 'tool_emailtemplate'),
-        get_string('imagesdesc', 'tool_emailtemplate'),
-        'images',
-        0,
-        ['maxfiles' => 8, 'accepted_types' => ['web_image']]
+    $ADMIN->add('tool_emailtemplate', new admin_externalpage(
+        'tool_emailtemplate_template',
+        get_string('emailtemplate:manage', 'tool_emailtemplate'),
+        new moodle_url('/admin/tool/emailtemplate/template.php'),
+        'tool/emailtemplate:manage'
     ));
 
     $settings->add(new admin_setting_configcheckbox(

--- a/template.php
+++ b/template.php
@@ -1,0 +1,57 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Modify the email template
+ *
+ * @package    tool_emailtemplate
+ * @author     Benjamin Walker <benjaminwalker@catalyst-au.net>
+ * @copyright  2024, Catalyst IT
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+require_once(__DIR__ . '/../../../config.php');
+
+// This is locked behind a separate capability so the task can be delegated to non-admins.
+require_login();
+$context = context_system::instance();
+require_capability('tool/emailtemplate:manage', $context);
+
+// Set up the page.
+$url = new moodle_url('/admin/tool/emailtemplate/template.php');
+$PAGE->set_url($url);
+$PAGE->set_context($context);
+$PAGE->set_pagelayout('admin');
+$PAGE->set_title(get_string('emailtemplate:manage', 'tool_emailtemplate'));
+$PAGE->set_heading($SITE->fullname);
+
+// Create the form and load current config.
+$mform = new \tool_emailtemplate\form\template();
+$mform->load_form_config();
+
+// Handle form submission.
+if ($mform->is_cancelled()) {
+    redirect(new moodle_url('/admin/tool/emailtemplate/index.php'));
+} else if ($data = $mform->get_data()) {
+    $mform->save_form_config($data);
+    redirect($url, get_string('changessaved'), null, \core\output\notification::NOTIFY_SUCCESS);
+}
+
+// Display the form.
+echo $OUTPUT->header();
+echo $OUTPUT->heading(get_string('emailtemplate:manage', 'tool_emailtemplate'));
+$mform->display();
+echo $OUTPUT->footer();

--- a/version.php
+++ b/version.php
@@ -25,8 +25,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2024031100;
-$plugin->release = 2024031100;
+$plugin->version = 20240120200;
+$plugin->release = 20240120200;
 $plugin->requires = 2017051500;    // Our lowest supported Moodle (3.3.0).
 $plugin->supported = [39, 401];    // Available as of Moodle 3.9.0 or later.
 $plugin->component = 'tool_emailtemplate';

--- a/version.php
+++ b/version.php
@@ -25,10 +25,10 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 20240120200;
-$plugin->release = 20240120200;
+$plugin->version = 20240120300;
+$plugin->release = 20240120300;
 $plugin->requires = 2017051500;    // Our lowest supported Moodle (3.3.0).
-$plugin->supported = [39, 401];    // Available as of Moodle 3.9.0 or later.
+$plugin->supported = [39, 404];    // Available as of Moodle 3.9.0 or later.
 $plugin->component = 'tool_emailtemplate';
 $plugin->maturity = MATURITY_STABLE;
 $plugin->dependencies = [];


### PR DESCRIPTION
- Adds new manage capability
- Moves template settings to new template page
- Still uses same config and logs config changes (does not log changes in images - logging for that was already somewhat broken and only showing the first image)